### PR TITLE
Add test containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,20 @@ jobs:
           java-version: '11'
           architecture: x64
 
-      - name: Tests
+      - name: Tests H2
         run: ./gradlew check
+
+      - name: Tests MySQL
+        if: "( contains(github.event.head_commit.message, '[release]') || contains(github.event.head_commit.message, '[test all]') )"
+        run: ./gradlew check
+        env:
+          MIGTOOL_DB: mysql
+
+      - name: Tests MariaDB
+        if: "( contains(github.event.head_commit.message, '[release]') || contains(github.event.head_commit.message, '[test all]') )"
+        run: ./gradlew check
+        env:
+          MIGTOOL_DB: mariadb
 
       - name: Release
         if: "contains(github.event.head_commit.message, '[release]')"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Ignore Gradle build output directory
 build
+
+# Ignore database files directory
+.db

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ java {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
@@ -29,15 +28,23 @@ dependencies {
     // This dependency is used by the application.
     implementation "ch.qos.logback:logback-classic:1.2.3"
     runtimeOnly 'mysql:mysql-connector-java:8.0.22'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:2.7.4'
     runtimeOnly 'com.h2database:h2:1.4.200'
 
     // Use the latest Groovy version for Spock testing
-    testImplementation 'org.codehaus.groovy:groovy-all:2.5.12'
-    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.codehaus.groovy:groovy-all:3.0.8'
+    testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
+    testImplementation "org.testcontainers:testcontainers:1.16.0"
 
     // Dummy library containing some migration files among their resources for testing purposes
     testImplementation files("libs/jar-with-resources.jar")
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 application {

--- a/src/test/groovy/io/seqera/migtool/MigToolTest.groovy
+++ b/src/test/groovy/io/seqera/migtool/MigToolTest.groovy
@@ -3,22 +3,22 @@
  */
 package io.seqera.migtool
 
+
 import java.nio.file.Files
+
 import io.seqera.migtool.resources.ClassFromJarWithResources
+import io.seqera.migtool.util.database.DatabaseSpecification
 
-import spock.lang.Specification
-
-class MigToolTest extends Specification {
-
+class MigToolTest extends DatabaseSpecification {
 
     def 'should init migtool' () {
         given:
         def tool = new MigTool()
-            .withDriver('org.h2.Driver')
-            .withDialect('h2')
-            .withUrl('jdbc:h2:mem:test')
-            .withUser('sa')
-            .withPassword('')
+            .withDriver(database.config.driver)
+            .withDialect(database.config.dialect)
+            .withUrl(database.config.url)
+            .withUser(database.config.user)
+            .withPassword(database.config.password)
             .withLocations('classpath:test')
 
         when:
@@ -34,7 +34,6 @@ class MigToolTest extends Specification {
         tool.existTable(MigTool.MIGTOOL_TABLE)
     }
 
-
     def 'should apply local file migration' () {
         given:
         def folder = Files.createTempDirectory('test')
@@ -42,13 +41,13 @@ class MigToolTest extends Specification {
         folder.resolve('V02__file2.sql').text = 'create table YYY ( col2 varchar(2) ); create table ZZZ ( col3 varchar(3) );'
         folder.resolve('x03__xyz.txt').text = 'This field should be ignored'
         and:
-
+        def config = database.getConfig()
         def tool = new MigTool()
-                .withDriver('org.h2.Driver')
-                .withDialect('h2')
-                .withUrl('jdbc:h2:mem:test')
-                .withUser('sa')
-                .withPassword('')
+                .withDriver(database.config.driver)
+                .withDialect(database.config.dialect)
+                .withUrl(database.config.url)
+                .withUser(database.config.user)
+                .withPassword(database.config.password)
                 .withLocations("file:$folder")
 
         when:
@@ -87,11 +86,11 @@ class MigToolTest extends Specification {
     def 'should apply class path migration' () {
         given:
         def tool = new MigTool()
-                .withDriver('org.h2.Driver')
-                .withDialect('h2')
-                .withUrl('jdbc:h2:mem:test')
-                .withUser('sa')
-                .withPassword('')
+                .withDriver(database.config.driver)
+                .withDialect(database.config.dialect)
+                .withUrl(database.config.url)
+                .withUser(database.config.user)
+                .withPassword(database.config.password)
                 .withLocations("classpath:db/mariadb")
 
         when:
@@ -127,11 +126,11 @@ class MigToolTest extends Specification {
     def 'should apply class path migration with custom pattern' () {
         given:
         def tool = new MigTool()
-                .withDriver('org.h2.Driver')
-                .withDialect('h2')
-                .withUrl('jdbc:h2:mem:test')
-                .withUser('sa')
-                .withPassword('')
+                .withDriver(database.config.driver)
+                .withDialect(database.config.dialect)
+                .withUrl(database.config.url)
+                .withUser(database.config.user)
+                .withPassword(database.config.password)
                 .withLocations("classpath:db/mariadb")
                 .withPattern(/v(\d\d)-.+/)
 
@@ -153,11 +152,11 @@ class MigToolTest extends Specification {
     def 'should apply migration coming from a jar file' () {
         given:
         def tool = new MigTool()
-                .withDriver('org.h2.Driver')
-                .withDialect('h2')
-                .withUrl('jdbc:h2:mem:test')
-                .withUser('sa')
-                .withPassword('')
+                .withDriver(database.config.driver)
+                .withDialect(database.config.dialect)
+                .withUrl(database.config.url)
+                .withUser(database.config.user)
+                .withPassword(database.config.password)
                 .withClassLoader(ClassFromJarWithResources.classLoader)
                 .withLocations("classpath:db/migrations")
 

--- a/src/test/groovy/io/seqera/migtool/util/database/DatabaseSpecification.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/DatabaseSpecification.groovy
@@ -1,0 +1,17 @@
+package io.seqera.migtool.util.database
+
+import spock.lang.Specification
+
+import io.seqera.migtool.util.database.factory.DatabaseFactory
+import io.seqera.migtool.util.database.factory.Database
+
+
+abstract class DatabaseSpecification extends Specification {
+
+    protected static final Database database = DatabaseFactory.database
+
+    void cleanupSpec() {
+        database.cleanup()
+    }
+
+}

--- a/src/test/groovy/io/seqera/migtool/util/database/DbConfig.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/DbConfig.groovy
@@ -1,0 +1,22 @@
+package io.seqera.migtool.util.database
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class DbConfig {
+
+    final String url
+    final String user
+    final String password
+    final String driver
+    final String dialect
+
+    DbConfig(String url, String user, String password, String driver, String dialect) {
+        this.url = url
+        this.user = user
+        this.password = password
+        this.driver = driver
+        this.dialect = dialect
+    }
+
+}

--- a/src/test/groovy/io/seqera/migtool/util/database/factory/AbstractDatabase.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/factory/AbstractDatabase.groovy
@@ -1,0 +1,76 @@
+package io.seqera.migtool.util.database.factory
+
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.ResultSet
+import java.sql.ResultSetMetaData
+import java.sql.Statement
+
+import groovy.transform.CompileStatic
+import io.seqera.migtool.util.database.DbConfig
+
+@CompileStatic
+abstract class AbstractDatabase implements Database {
+
+    void cleanup() {
+        DbConfig config = getConfig()
+
+        try ( Connection conn = DriverManager.getConnection(config.url, config.user, config.password) ) {
+
+            def tables = executeStatement(conn, listTablesDDL)
+
+            String disableChecksStatement = getConstraintsCheckDDL(false)
+            executeStatement(conn, disableChecksStatement)
+
+            tables.each { row ->
+                String dropTableStatement = getDropTableDDL(row.values().first())
+                executeStatement(conn, dropTableStatement)
+            }
+
+            String enableChecksStatement = getConstraintsCheckDDL(true)
+            executeStatement(conn, enableChecksStatement)
+
+        }
+    }
+
+    protected String getDropTableDDL(String tableName) {
+        return "DROP TABLE IF EXISTS ${tableName};"
+    }
+
+    protected abstract String getListTablesDDL()
+    protected abstract String getConstraintsCheckDDL(boolean enable)
+
+    private static List<Map<String, String>> executeStatement(Connection connection, String statement) {
+        try (Statement stm = connection.createStatement() ) {
+            stm.execute(statement)
+
+            return extractResultSet(stm.resultSet)
+        }
+    }
+
+    private static List<Map<String, String>> extractResultSet(ResultSet resultSet) {
+        if (!resultSet)
+            return []
+
+        List<Map<String, String>> rows = []
+        while (resultSet.next())
+            rows << extractRow(resultSet)
+
+        return rows
+    }
+
+    private static Map<String, String> extractRow(ResultSet resultSet) {
+        ResultSetMetaData metadata = resultSet.metaData
+
+        Map<String, String> row = [:]
+        for (int i = 1; i <= metadata.columnCount; ++i) {
+            String key = metadata.getColumnName(i)
+            String value = resultSet.getString(i)
+
+            row[key] = value
+        }
+
+        return row
+    }
+
+}

--- a/src/test/groovy/io/seqera/migtool/util/database/factory/ContainerizedDatabase.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/factory/ContainerizedDatabase.groovy
@@ -1,0 +1,31 @@
+package io.seqera.migtool.util.database.factory
+
+import groovy.transform.CompileStatic
+import groovy.transform.Memoized
+import groovy.util.logging.Slf4j
+import io.seqera.migtool.util.database.DbConfig
+import org.testcontainers.containers.GenericContainer
+
+@Slf4j
+@CompileStatic
+abstract class ContainerizedDatabase extends AbstractDatabase {
+
+    protected GenericContainer container
+
+    @Override
+    @Memoized
+    DbConfig getConfig() {
+        if (!container?.running)
+            throw new IllegalStateException('Container still not running')
+
+        return createConfig()
+    }
+
+    protected void start() {
+        log.debug("Starting container")
+        container.start()
+    }
+
+    protected abstract DbConfig createConfig()
+
+}

--- a/src/test/groovy/io/seqera/migtool/util/database/factory/Database.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/factory/Database.groovy
@@ -1,0 +1,14 @@
+
+package io.seqera.migtool.util.database.factory
+
+import groovy.transform.CompileStatic
+import io.seqera.migtool.util.database.DbConfig
+
+@CompileStatic
+interface Database {
+
+    DbConfig getConfig()
+
+    void cleanup()
+
+}

--- a/src/test/groovy/io/seqera/migtool/util/database/factory/DatabaseFactory.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/factory/DatabaseFactory.groovy
@@ -1,0 +1,30 @@
+package io.seqera.migtool.util.database.factory
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+
+@Slf4j
+@CompileStatic
+final class DatabaseFactory {
+
+    private enum DatabaseType { mysql, mariadb, postgres, h2 }
+
+    private DatabaseFactory() {}
+
+    static Database getDatabase() {
+        String db = System.getenv('MIGTOOL_DB') ?: 'h2'
+        DatabaseType databaseType = determineDatabaseType(db)
+
+        if (databaseType == DatabaseType.h2) return new H2Database()
+        if (databaseType == DatabaseType.mysql) return new MySqlDatabase('5.6')
+        if (databaseType == DatabaseType.mariadb) return new MariaDbDatabase()
+
+        log.info("Unknown DB type: '${db}'")
+        return new H2Database()
+    }
+
+    private static DatabaseType determineDatabaseType(String db) {
+        return DatabaseType.values().find { it.toString() == db }
+    }
+
+}

--- a/src/test/groovy/io/seqera/migtool/util/database/factory/H2Database.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/factory/H2Database.groovy
@@ -1,0 +1,39 @@
+package io.seqera.migtool.util.database.factory
+
+import groovy.transform.Memoized
+import io.seqera.migtool.util.database.DbConfig
+
+class H2Database extends AbstractDatabase {
+
+    private static final String user = 'sa'
+    private static final String password = ''
+    private static final String schema = 'test'
+
+    protected H2Database() {}
+
+    @Override
+    @Memoized
+    DbConfig getConfig() {
+        return new DbConfig(
+                "jdbc:h2:file:./.db/h2/${schema};DB_CLOSE_ON_EXIT=FALSE",
+                user,
+                password,
+                'org.h2.Driver',
+                'h2'
+        )
+    }
+
+    @Override
+    protected String getListTablesDDL() {
+        return """
+            SELECT t.table_name FROM information_schema.tables t
+            WHERE (t.table_schema = 'PUBLIC') AND (t.table_type LIKE '%TABLE')
+        """
+    }
+
+    @Override
+    protected String getConstraintsCheckDDL(boolean enable) {
+        return "SET REFERENTIAL_INTEGRITY ${enable.toString().toUpperCase()};"
+    }
+
+}

--- a/src/test/groovy/io/seqera/migtool/util/database/factory/MariaDbDatabase.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/factory/MariaDbDatabase.groovy
@@ -1,0 +1,55 @@
+package io.seqera.migtool.util.database.factory
+
+import io.seqera.migtool.util.database.DbConfig
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+class MariaDbDatabase extends ContainerizedDatabase {
+
+    private static final String user = 'test'
+    private static final String password = 'test'
+    private static final String schema = 'test'
+
+    private static final Map mariadbConfig = [
+        MYSQL_ROOT_PASSWORD: 'root',
+        MYSQL_USER: user,
+        MYSQL_PASSWORD: password,
+        MYSQL_DATABASE: schema
+    ]
+
+    protected MariaDbDatabase() {
+        container = new GenericContainer("mariadb:10")
+                .withExposedPorts(3306)
+                .withEnv(mariadbConfig)
+                .waitingFor(Wait.forListeningPort())
+                .waitingFor(Wait.forLogMessage(/.*ready for connections.*/, 1))
+                .waitingFor(Wait.forLogMessage(/.*3306\s+mariadb.org binary distribution.*/, 1))
+
+        start()
+    }
+
+    @Override
+    String getListTablesDDL() {
+        return """
+            SELECT t.table_name FROM information_schema.tables t
+            WHERE (t.table_schema = '${schema}') AND
+                  (t.table_name NOT LIKE '%_sequence') AND (t.table_type LIKE '%TABLE')
+        """
+    }
+
+    @Override
+    String getConstraintsCheckDDL(boolean enable) {
+        return "SET FOREIGN_KEY_CHECKS=${enable ? 1 : 0};"
+    }
+
+    @Override
+    protected DbConfig createConfig() {
+        return new DbConfig(
+                "jdbc:mariadb://localhost:${container.firstMappedPort}/${schema}",
+                user,
+                password,
+                'org.mariadb.jdbc.Driver',
+                'mariadb'
+        )
+    }
+}

--- a/src/test/groovy/io/seqera/migtool/util/database/factory/MySqlDatabase.groovy
+++ b/src/test/groovy/io/seqera/migtool/util/database/factory/MySqlDatabase.groovy
@@ -1,0 +1,57 @@
+package io.seqera.migtool.util.database.factory
+
+import io.seqera.migtool.util.database.DbConfig
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+class MySqlDatabase extends ContainerizedDatabase {
+
+    private static final String user = 'test'
+    private static final String password = 'test'
+    private static final String schema = 'test'
+
+    private static final Map mysqlConfig = [
+        MYSQL_ROOT_PASSWORD: 'root',
+        MYSQL_USER: user,
+        MYSQL_PASSWORD: password,
+        MYSQL_DATABASE: schema
+    ]
+
+    protected MySqlDatabase(String version) {
+        container = new GenericContainer("mysql:${version}")
+                .withExposedPorts(3306)
+                .withEnv(mysqlConfig)
+                .withTmpFs(['/var/lib/mysql':'rw,noexec,nosuid,size=1024m'])
+                .waitingFor(Wait.forListeningPort())
+                .waitingFor(Wait.forLogMessage(/.*mysqld: ready for connections.*/, 1))
+                .waitingFor(Wait.forLogMessage(/.*; port: 3306.*/, 1))
+
+        start()
+    }
+
+    @Override
+    protected String getListTablesDDL() {
+        return """
+            SELECT t.table_name FROM information_schema.tables t
+            WHERE (t.table_schema = '${schema}') AND
+                  (t.table_name NOT LIKE '%_sequence') AND (t.table_type LIKE '%TABLE')
+        """
+    }
+
+    @Override
+    protected String getConstraintsCheckDDL(boolean enable) {
+        return "SET FOREIGN_KEY_CHECKS=${enable ? 1 : 0};"
+    }
+
+    @Override
+    protected DbConfig createConfig() {
+        return new DbConfig(
+                "jdbc:mysql://localhost:${container.firstMappedPort}/${schema}",
+                user,
+                password,
+                'com.mysql.cj.jdbc.Driver',
+                'mysql'
+        )
+    }
+
+}


### PR DESCRIPTION
### Description
- Add support for running the tests against the supported databases (some statements run by the tool were found to be invalid in [PostgreSQL](https://github.com/seqeralabs/migtool/pull/2)).
- Add missing MariaDB driver dependency.
- Upgrade to Spock 2 and Groovy 3.