### PR TITLE
Add launcher cli + improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,11 @@ jobs:
           name: migtool_linux
           path: build/native/nativeCompile/migtool
 
+      - name: Tests native
+        run: ./gradlew cleanTest check
+        env:
+          NATIVE_BINARY_PATH: build/native/nativeCompile/migtool
+
   release:
     name: Release
     if: "contains(github.event.head_commit.message, '[release]') && github.event.ref=='refs/heads/master'"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@
  */
 
 plugins {
+    id 'java'
+    id 'groovy'
     id 'application'
     id 'org.graalvm.buildtools.native' version '0.9.10'
 }
@@ -29,14 +31,27 @@ dependencies {
     implementation "ch.qos.logback:logback-classic:1.2.3"
     runtimeOnly 'mysql:mysql-connector-java:8.0.22'
     runtimeOnly 'com.h2database:h2:1.4.200'
-
+    runtimeOnly 'mysql:mysql-connector-java:8.0.28'
+    implementation 'info.picocli:picocli:4.6.3'
+    annotationProcessor 'info.picocli:picocli-codegen:4.6.3'
+    
     // Use the latest Groovy version for Spock testing
-    testImplementation 'org.codehaus.groovy:groovy-all:2.5.12'
-    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+    testImplementation "org.codehaus.groovy:groovy:3.0.9"
+    testImplementation "org.codehaus.groovy:groovy-nio:3.0.9"
+    testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
+    testImplementation "org.spockframework:spock-core"
+    testImplementation "org.spockframework:spock-junit4"  // you can remove this if your code does not rely on old JUnit 4 rules
     testImplementation 'junit:junit:4.13'
+    testImplementation "org.testcontainers:testcontainers:1.16.3"
+    testImplementation "org.testcontainers:mysql:1.16.3"
+    testImplementation "org.testcontainers:spock:1.16.3"
 
     // Dummy library containing some migration files among their resources for testing purposes
     testImplementation files("libs/jar-with-resources.jar")
+}
+
+test {
+    useJUnitPlatform()
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,12 @@ repositories {
     mavenCentral()
 }
 
+def nativeCliTest = sourceSets.create('nativeCliTest')
+
+configurations[nativeCliTest.implementationConfigurationName].extendsFrom(configurations.testImplementation)
+configurations[nativeCliTest.runtimeOnlyConfigurationName].extendsFrom(configurations.testRuntimeOnly)
+
+
 dependencies {
     // This dependency is used by the application.
     implementation "ch.qos.logback:logback-classic:1.2.3"
@@ -48,6 +54,9 @@ dependencies {
 
     // Dummy library containing some migration files among their resources for testing purposes
     testImplementation files("libs/jar-with-resources.jar")
+
+    nativeCliTestImplementation project
+    nativeCliTestImplementation "org.codehaus.groovy:groovy-sql:3.0.9"
 }
 
 test {
@@ -82,7 +91,23 @@ graalvmNative {
             buildArgs.add('-H:EnableURLProtocols=https,http')
             buildArgs.add('-H:+ReportExceptionStackTraces')
             buildArgs.add('-H:-CheckToolchain')
-
+            buildArgs.add('-H:IncludeResources=.*/TlsSettings.properties$')
         }
     }
+}
+
+def nativeCliTestTask = tasks.register('nativeCliTest', Test) {
+    description = 'Runs nativeCli tests.'
+    group = 'verification'
+    useJUnitPlatform()
+
+    testClassesDirs = nativeCliTest.output.classesDirs
+    classpath = configurations[nativeCliTest.runtimeClasspathConfigurationName] + nativeCliTest.output
+
+    dependsOn nativeCompile
+    environment 'NATIVE_BINARY_PATH', "$buildDir/native/nativeCompile/migtool"
+}
+
+tasks.named('check') {
+    dependsOn(nativeCliTestTask)
 }

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -30,6 +30,28 @@
   "name":"char[]"}
 ,
 {
+  "name":"com.mysql.cj.conf.url.SingleConnectionUrl",
+  "methods":[{"name":"<init>","parameterTypes":["com.mysql.cj.conf.ConnectionUrlParser","java.util.Properties"] }]}
+,
+{
+  "name":"com.mysql.cj.exceptions.CJCommunicationsException",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]}
+,
+{
+  "name":"com.mysql.cj.jdbc.AbandonedConnectionCleanupThread"}
+,
+{
+  "name":"com.mysql.cj.jdbc.Driver"}
+,
+{
+  "name":"com.mysql.cj.log.StandardLogger",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]}
+,
+{
+  "name":"com.mysql.cj.protocol.StandardSocketFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]}
+,
+{
   "name":"com.sun.crypto.provider.AESCipher$General",
   "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,
@@ -100,6 +122,9 @@
   "allDeclaredConstructors":true}
 ,
 {
+  "name":"java.io.FilePermission"}
+,
+{
   "name":"java.io.Serializable",
   "allDeclaredMethods":true}
 ,
@@ -162,6 +187,9 @@
   "name":"java.lang.Object[]"}
 ,
 {
+  "name":"java.lang.RuntimePermission"}
+,
+{
   "name":"java.lang.String"}
 ,
 {
@@ -185,6 +213,16 @@
   "queryAllDeclaredConstructors":true}
 ,
 {
+  "name":"java.net.NetPermission"}
+,
+{
+  "name":"java.net.SocketPermission"}
+,
+{
+  "name":"java.net.URLPermission",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String","java.lang.String"] }]}
+,
+{
   "name":"java.nio.file.Path"}
 ,
 {
@@ -195,6 +233,9 @@
   "name":"java.security.AlgorithmParametersSpi"}
 ,
 {
+  "name":"java.security.AllPermission"}
+,
+{
   "name":"java.security.KeyStoreSpi"}
 ,
 {
@@ -202,6 +243,9 @@
 ,
 {
   "name":"java.security.SecureRandomParameters"}
+,
+{
+  "name":"java.security.SecurityPermission"}
 ,
 {
   "name":"java.security.interfaces.ECPrivateKey"}
@@ -380,6 +424,9 @@
   "name":"java.util.Locale[]"}
 ,
 {
+  "name":"java.util.PropertyPermission"}
+,
+{
   "name":"java.util.concurrent.LinkedTransferQueue",
   "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,
@@ -397,6 +444,14 @@
 ,
 {
   "name":"long[]"}
+,
+{
+  "name":"org.h2.Driver"}
+,
+{
+  "name":"picocli.CommandLine$AutoHelpMixin",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true}
 ,
 {
   "name":"sun.misc.Unsafe",

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -2,6 +2,15 @@
   "resources":{
   "includes":[
     {
+      "pattern":"\\QMETA-INF/services/java.sql.Driver\\E"
+    }, 
+    {
+      "pattern":"\\Q\\E"
+    }, 
+    {
+      "pattern":"\\Qorg/slf4j/impl/StaticLoggerBinder.class\\E"
+    }, 
+    {
       "pattern":"\\Qschema/h2.sql\\E"
     }, 
     {
@@ -11,6 +20,7 @@
       "pattern":"\\Qschema/mysql.sql\\E"
     }
   ]},
-  "bundles":[
-  ]
+  "bundles":[{
+      "name":"com.mysql.cj.LocalizedErrorMessages"
+    }]
 }

--- a/src/main/java/io/seqera/migtool/App.java
+++ b/src/main/java/io/seqera/migtool/App.java
@@ -1,28 +1,71 @@
 package io.seqera.migtool;
 
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 /**
  * Mig tool main launcher
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-public class App {
+@Command(name = "migtool", mixinStandardHelpOptions = true, description = "Database schema migration tool")
+public class App implements Callable<Integer> {
+
+    private static System.Logger logger = System.getLogger(App.class.getSimpleName());
+
+    @Option(names = {"-u", "--username"}, description = "DB connection user")
+    private String username;
+
+    @Option(names = {"-p", "--password"}, description = "DB connection password")
+    private String password;
+
+    @Option(names = {"--url"}, description = "DB connection URL (uses JDBC syntax)")
+    private String url;
+
+    @Option(names = {"--dialect"}, description = "DB dialect")
+    private String dialect = "mysql";
+
+    @Option(names = {"--driver"}, description = "JDBC driver class name")
+    private String driver;
+
+    @Option(names = {"--locations"}, description = "DB migration scripts location path (local path should be prefixed with `file:`)")
+    private String locations;
+
+    @Option(names = {"--pattern"}, description = "DB migration scripts file names pattern")
+    private String pattern = "^m(\\d+)__(.+)";
+
+    @Override
+    public Integer call() throws Exception {
+
+        // set optional fields
+        MigTool tool = new MigTool()
+                .withUser(username)
+                .withPassword(password)
+                .withUrl(url)
+                .withDialect(dialect)
+                .withDriver(driver)
+                .withLocations(locations)
+                .withPattern(pattern);
+
+        try {
+            tool.run();
+            return 0;
+        }
+        catch (Throwable e) {
+            final String msg = e.getMessage();
+            if( msg != null )
+                logger.log(System.Logger.Level.ERROR, msg);
+            else
+                logger.log(System.Logger.Level.ERROR, e.toString(), e);
+            return 1;
+        }
+    }
 
     public static void main(String[] args) {
-        if( args.length != 7){
-            System.out.println("invalid arguments");
-            System.out.println("user password url dialect driver locations pattern");
-            System.exit(-1);
-            return;
-        }
-        MigTool tool = new MigTool()
-                .withUser(args[0])
-                .withPassword(args[1])
-                .withUrl(args[2])
-                .withDialect(args[3])
-                .withDriver(args[4])
-                .withLocations(args[5])
-                .withClassLoader(App.class.getClassLoader())
-                .withPattern(args[6]);
-        tool.run();
+        int exitCode = new CommandLine(new App()).execute(args);
+        System.exit(exitCode);
     }
+
 }

--- a/src/main/java/io/seqera/migtool/MigTool.java
+++ b/src/main/java/io/seqera/migtool/MigTool.java
@@ -176,6 +176,9 @@ public class MigTool {
         }
 
         try( Connection conn = getConnection() ) {
+            if( conn == null )
+                throw new IllegalStateException("Unable to aquire DB connection");
+
             // retrieve the database schema
             if( schema==null || schema.isEmpty() ) {
                 schema = conn.getSchema();

--- a/src/nativeCliTest/groovy/io/seqera/migtool/MysqlTest.groovy
+++ b/src/nativeCliTest/groovy/io/seqera/migtool/MysqlTest.groovy
@@ -1,0 +1,53 @@
+package io.seqera.migtool
+
+import groovy.sql.Sql
+import org.testcontainers.containers.MySQLContainer
+import spock.lang.Specification
+import spock.lang.Timeout
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class MysqlTest extends Specification {
+
+    static MySQLContainer container
+
+    static {
+        container = new MySQLContainer("mysql:5.6")
+        // start it -- note: it's stopped automatically
+        // https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/
+        container.start()
+    }
+
+    @Timeout(30)
+    def 'should run native binary' () {
+        given:
+        def BIN = System.getenv('NATIVE_BINARY_PATH')
+        def CLI = [BIN,
+                '-u', container.username,
+                '-p', container.password,
+                '--url', container.jdbcUrl,
+                '--driver', 'com.mysql.cj.jdbc.Driver',
+                '--dialect', 'mysql',
+                '--locations', 'file:src/test/resources/migrate-db/mysql' ]
+
+        when:
+        println "Running: ${CLI.join( )}"
+        def proc = new ProcessBuilder()
+                .command(CLI)
+                .redirectErrorStream(true)
+                .start()
+        and:
+        def result = proc.waitFor()
+        if( result!=0 )
+            System.err.println(proc.text)
+        
+        then:
+        result == 0
+
+        and:
+        Sql.newInstance(container.jdbcUrl, container.username, container.password)
+                .rows("SELECT table_name FROM information_schema.tables where table_name='license'")
+    }
+}

--- a/src/test/groovy/io/seqera/migtool/MysqlTest.groovy
+++ b/src/test/groovy/io/seqera/migtool/MysqlTest.groovy
@@ -1,0 +1,75 @@
+package io.seqera.migtool
+
+import org.testcontainers.containers.MySQLContainer
+import spock.lang.IgnoreIf
+import spock.lang.Requires
+import spock.lang.Specification
+import spock.lang.Timeout
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class MysqlTest extends Specification {
+
+    private static final int PORT = 3306
+
+
+    static MySQLContainer container
+
+    static {
+        container = new MySQLContainer("mysql:5.6")
+        // start it -- note: it's stopped automatically
+        // https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/
+        container.start()
+    }
+
+    @IgnoreIf({System.getenv('NATIVE_BINARY_PATH')})
+    def 'should do something'  () {
+        given:
+        def tool = new MigTool()
+                .withDriver('com.mysql.cj.jdbc.Driver')
+                .withDialect('mysql')
+                .withUrl(container.getJdbcUrl())
+                .withUser(container.getUsername())
+                .withPassword(container.getPassword())
+                .withLocations('file:src/test/resources/migrate-db/mysql')
+
+        when:
+        tool.run()
+
+        then:
+        tool.existTable(tool.getConnection(), 'organization')
+        tool.existTable(tool.getConnection(), 'license')
+        !tool.existTable(tool.getConnection(), 'foo')
+
+    }
+
+    @Timeout(30)
+    @Requires({System.getenv('NATIVE_BINARY_PATH')})
+    def 'should run native binary' () {
+        given:
+        def BIN = System.getenv('NATIVE_BINARY_PATH')
+        def CLI = [BIN,
+                '-u', container.getUsername(),
+                '-p', container.getPassword(),
+                '--url', container.getJdbcUrl(),
+                '--driver', 'com.mysql.cj.jdbc.Driver',
+                '--dialect', 'mysql',
+                '--locations', 'file:src/test/resources/migrate-db/mysql' ]
+
+        when:
+        println "Running: ${CLI.join( )}"
+        def proc = new ProcessBuilder()
+                .command(CLI)
+                .redirectErrorStream(true)
+                .start()
+        and:
+        def result = proc.waitFor()
+        if( result!=0 )
+            System.err.println(proc.text)
+        
+        then:
+        result == 0
+    }
+}

--- a/src/test/groovy/io/seqera/migtool/MysqlTest.groovy
+++ b/src/test/groovy/io/seqera/migtool/MysqlTest.groovy
@@ -24,7 +24,6 @@ class MysqlTest extends Specification {
         container.start()
     }
 
-    @IgnoreIf({System.getenv('NATIVE_BINARY_PATH')})
     def 'should do something'  () {
         given:
         def tool = new MigTool()
@@ -45,31 +44,4 @@ class MysqlTest extends Specification {
 
     }
 
-    @Timeout(30)
-    @Requires({System.getenv('NATIVE_BINARY_PATH')})
-    def 'should run native binary' () {
-        given:
-        def BIN = System.getenv('NATIVE_BINARY_PATH')
-        def CLI = [BIN,
-                '-u', container.getUsername(),
-                '-p', container.getPassword(),
-                '--url', container.getJdbcUrl(),
-                '--driver', 'com.mysql.cj.jdbc.Driver',
-                '--dialect', 'mysql',
-                '--locations', 'file:src/test/resources/migrate-db/mysql' ]
-
-        when:
-        println "Running: ${CLI.join( )}"
-        def proc = new ProcessBuilder()
-                .command(CLI)
-                .redirectErrorStream(true)
-                .start()
-        and:
-        def result = proc.waitFor()
-        if( result!=0 )
-            System.err.println(proc.text)
-        
-        then:
-        result == 0
-    }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2019-2020, Seqera Labs.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  ~
+  ~ This Source Code Form is "Incompatible With Secondary Licenses", as
+  ~ defined by the Mozilla Public License, v. 2.0.
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+        <withJansi>true</withJansi>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+</configuration>

--- a/src/test/resources/migrate-db/mysql/V01__create_organization_table.sql
+++ b/src/test/resources/migrate-db/mysql/V01__create_organization_table.sql
@@ -1,0 +1,42 @@
+/**
+ * Schema migration example
+ */
+CREATE TABLE `organization`
+(
+    `id`           varchar(25)  NOT NULL,
+    `company`      varchar(125) NOT NULL,
+    `contact`      varchar(125) NOT NULL,
+    `email`        varchar(125) NOT NULL,
+    `address`      varchar(255)          DEFAULT NULL,
+    `zip`          varchar(25)           DEFAULT NULL,
+    `country`      varchar(125)           DEFAULT NULL,
+    `deleted`      tinyint(1)   NOT NULL DEFAULT 0,
+    `date_created` datetime     NOT NULL,
+    `last_updated` datetime     NOT NULL,
+    PRIMARY KEY (id)
+)
+    ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `license`
+(
+    `id`              varchar(25) NOT NULL,
+    `features`        varchar(255) NOT NULL,
+    `product`         varchar(75) NOT NULL,
+    `contact`         varchar(125) NOT NULL,
+    `email`           varchar(125) NOT NULL,
+    `secret`          blob         NOT NULL,
+    `organization_id` varchar(25) NOT NULL,
+    `activation`      datetime    NOT NULL,
+    `expiration`      datetime    NOT NULL,
+    `date_created`    datetime    NOT NULL,
+    `last_updated`    datetime    NOT NULL,
+    `last_accessed`   datetime,
+    `last_access_ip`  varchar(255)          DEFAULT NULL,
+    `access_count`    int(11)      NOT NULL DEFAULT 0,
+    `suspended`       tinyint(1)   NOT NULL DEFAULT 0,
+    `deleted`         tinyint(1)   NOT NULL DEFAULT 0,
+    `expired`         tinyint(1)   NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    FOREIGN KEY (organization_id) REFERENCES organization(id)
+)
+    ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;


### PR DESCRIPTION
This commmit adds several improvements:

- Implements a launcher cli app that allows running the
  migtool from the command line. Usual options as DB user,
  password, connection URL, etc. need to be provided a CLI
  parameters.
- Add testcontainer test for MySQL
- Include MySQL 8 JDBC driver in target bundle
- Update Groovy and Spock runtime
- Native binary migration test againt MySQL