### PR TITLE
fix: incorrect sqlite driver

### DIFF
--- a/src/main/java/io/seqera/migtool/Helper.java
+++ b/src/main/java/io/seqera/migtool/Helper.java
@@ -215,7 +215,7 @@ public class Helper {
         if( "h2".equals(dialect))
             return "org.h2.Driver";
         if( "sqlite".equals(dialect))
-            return "org.sqlite.Driver";
+            return "org.sqlite.JDBC";
         return null;
     }
 }


### PR DESCRIPTION
The sqlite driver is `org.sqlite.JDBC` but is referenced in the code as `org.sqlite.Driver`. Current workaround is to provide `--driver org.sqlite.JDBC`.