### PR TITLE
Reverts compatibility of compileJava to 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ java {
     }
 
     compileJava {
-        // Set binary compatibility for Java compiler to 17
-        options.release.set(17)
+        // Set binary compatibility for Java compiler to 11 (worth checking to update this also)
+        options.release.set(11)
     }
 }
 


### PR DESCRIPTION
- @weronikasosnowskaseqera mentioned that some other projects might be using this tool with Java 11, so I revert this back until I am sure it is safe to update