### PR TITLE
chore: bumps the java compiler compatibility to 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -31,7 +31,8 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: '17.0.8'
-          distribution: 'graalvm'
+          distribution: 'graalvm-community'
+          native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install native-image component

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'java'
     id 'groovy'
     id 'application'
-    id 'org.graalvm.buildtools.native' version '0.9.28'
+    id 'org.graalvm.buildtools.native' version '0.10.0'
     id 'maven-publish'
 }
 
@@ -24,8 +24,8 @@ java {
     }
 
     compileJava {
-        // Set binary compatibility for Java compiler to 11 (worth checking to update this also)
-        options.release.set(11)
+        // Set binary compatibility for Java compiler to 17
+        options.release.set(17)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=2.2.2
+


### PR DESCRIPTION
- bumps the java compiler compatibility to 17, needed by projects that use micronaut 4
- bumps `actions/checkout` to v4
- sets the graalvm-ce edition correctly
- bumps `org.graalvm.buildtools.native` to 0.10.0

### Note
When a new version of migtool with this change is released, we should update the java version used by its dependencies to 17 ([license-man](https://github.com/seqeralabs/license-man))