### PR TITLE
Improve MigTool initialisation

### DIFF
--- a/src/main/java/io/seqera/migtool/App.java
+++ b/src/main/java/io/seqera/migtool/App.java
@@ -5,8 +5,6 @@ import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import static io.seqera.migtool.Helper.dialectFromUrl;
-import static io.seqera.migtool.Helper.driverFromUrl;
 
 /**
  * Mig tool main launcher
@@ -47,8 +45,8 @@ public class App implements Callable<Integer> {
                 .withUser(username)
                 .withPassword(password)
                 .withUrl(url)
-                .withDialect(dialect!=null ? dialect : dialectFromUrl(url))
-                .withDriver(driver!=null ? driver : driverFromUrl(url))
+                .withDialect(dialect)
+                .withDriver(driver)
                 .withLocations(location)
                 .withPattern(pattern);
 

--- a/src/main/java/io/seqera/migtool/MigTool.java
+++ b/src/main/java/io/seqera/migtool/MigTool.java
@@ -31,6 +31,8 @@ import groovy.sql.Sql;
 import io.seqera.migtool.template.SqlTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static io.seqera.migtool.Helper.dialectFromUrl;
+import static io.seqera.migtool.Helper.driverFromUrl;
 
 /**
  * Implement a simple migration tool inspired to Flyway
@@ -95,8 +97,10 @@ public class MigTool {
     }
 
     public MigTool withDialect(String dialect) {
-        this.dialect = dialect;
-        this.template = SqlTemplate.from(dialect);
+        if( dialect!=null ) {
+            this.dialect = dialect;
+            this.template = SqlTemplate.from(dialect);
+        }
         return this;
     }
 
@@ -177,6 +181,16 @@ public class MigTool {
      * Validate the expected input params and open the connection with the DB
      */
     protected void init() {
+        if( driver==null && url!=null ) {
+            withDriver(driverFromUrl(url));
+        }
+        if( dialect==null && url!=null ) {
+            withDialect(dialectFromUrl(url));
+        }
+        if( dialect!=null ) {
+            template = SqlTemplate.from(dialect);
+        }
+
         if( dialect==null || dialect.isEmpty() )
             throw new IllegalStateException("Missing 'dialect' attribute");
         if( url==null || url.isEmpty() )

--- a/src/test/groovy/io/seqera/migtool/MigToolTest.groovy
+++ b/src/test/groovy/io/seqera/migtool/MigToolTest.groovy
@@ -684,4 +684,23 @@ class MigToolTest extends Specification {
         tool.template.class == SqlTemplate.from('postgresql').class
     }
 
+    def 'should infer dialect and driver for url'() {
+        given:
+        def tool = new MigTool()
+                .withDriver('org.h2.Driver')
+                .withDialect('h2')
+                .withUrl('jdbc:h2:mem:test15;DB_CLOSE_DELAY=-1')
+                .withUser('sa')
+                .withPassword('')
+                .withLocations("/foo/bar")
+
+        when:
+        tool.init()
+        then:
+        tool.url == 'jdbc:h2:mem:test15;DB_CLOSE_DELAY=-1'
+        tool.driver == 'org.h2.Driver'
+        tool.dialect == 'h2'
+        tool.template.class == SqlTemplate.defaultTemplate().class
+    }
+
 }


### PR DESCRIPTION
Improve MigTool initialization so that `dialect` and `driver` can be inferred bu the DB `url` when omitted.  