### PR TITLE
Upgrade vulnerable dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,8 @@ configurations[nativeCliTest.runtimeOnlyConfigurationName].extendsFrom(configura
 dependencies {
     // This dependency is used by the application.
     implementation "ch.qos.logback:logback-classic:1.5.16"
-    runtimeOnly 'mysql:mysql-connector-java:8.0.33'
-    runtimeOnly 'com.h2database:h2:1.4.200'
-    runtimeOnly 'mysql:mysql-connector-java:8.0.33'
+    runtimeOnly 'com.mysql:mysql-connector-j:9.2.0'
+    runtimeOnly 'com.h2database:h2:2.2.224'
     runtimeOnly 'org.xerial:sqlite-jdbc:3.42.0.0'
     runtimeOnly("org.postgresql:postgresql:42.7.3")
     implementation 'info.picocli:picocli:4.6.3'

--- a/src/nativeCliTest/resources/migrate-db/h2/V01__create_organization_table.sql
+++ b/src/nativeCliTest/resources/migrate-db/h2/V01__create_organization_table.sql
@@ -10,7 +10,7 @@ CREATE TABLE `organization`
     `address`      varchar(255)          DEFAULT NULL,
     `zip`          varchar(25)           DEFAULT NULL,
     `country`      varchar(125)           DEFAULT NULL,
-    `deleted`      tinyint(1)   NOT NULL DEFAULT 0,
+    `deleted`      boolean   NOT NULL DEFAULT false,
     `date_created` datetime     NOT NULL,
     `last_updated` datetime     NOT NULL,
     PRIMARY KEY (id)
@@ -31,10 +31,10 @@ CREATE TABLE `license`
     `last_updated`    datetime    NOT NULL,
     `last_accessed`   datetime,
     `last_access_ip`  varchar(255)          DEFAULT NULL,
-    `access_count`    int(11)      NOT NULL DEFAULT 0,
-    `suspended`       tinyint(1)   NOT NULL DEFAULT 0,
-    `deleted`         tinyint(1)   NOT NULL DEFAULT 0,
-    `expired`         tinyint(1)   NOT NULL DEFAULT 0,
+    `access_count`    int       NOT NULL DEFAULT 0,
+    `suspended`       boolean   NOT NULL DEFAULT false,
+    `deleted`         boolean   NOT NULL DEFAULT false,
+    `expired`         boolean   NOT NULL DEFAULT false,
     PRIMARY KEY (id),
     FOREIGN KEY (organization_id) REFERENCES organization(id)
 );


### PR DESCRIPTION
- Upgrade MySQL connector dependency.
   - MySQL connector 9.x is compatible with MySQL 8.x only.
- Upgrade H2 dependency.
   - Fix test related to H2. 