### PR TITLE
Add support for MacOS-arm64 binary releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
 
-      - name: Setup Docker on macOS
-        if: runner.os == 'macOS'
-        uses: douglascamata/setup-docker-macos-action@v1.0.1
-        with:
-          colima-network-address: true
 
       - name: Tests
+        if: ${{ !(runner.os == 'macOS' && runner.arch == 'ARM64') }}
         run: ./gradlew check
 
       - name: Tests reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
         run: ./gradlew nativeCompile
 
       - name: Codesign binary
+        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -113,6 +114,7 @@ jobs:
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime build/native/nativeCompile/migtool -v
 
       - name: Notarize binary
+        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
         env:
           MACOS_AC_API_CERT: ${{ secrets.MACOS_AC_API_CERT }}
           MACOS_AC_API_ISSUER_ID: ${{ secrets.MACOS_AC_API_ISSUER_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,6 @@ jobs:
         run: ./gradlew nativeCompile
 
       - name: Codesign binary
-        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -114,7 +113,6 @@ jobs:
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime build/native/nativeCompile/migtool -v
 
       - name: Notarize binary
-        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
         env:
           MACOS_AC_API_CERT: ${{ secrets.MACOS_AC_API_CERT }}
           MACOS_AC_API_ISSUER_ID: ${{ secrets.MACOS_AC_API_ISSUER_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
 
+      - name: Setup Docker on macOS
+        if: runner.os == 'macOS'
+        uses: douglascamata/setup-docker-macos-action@v1.0.1
+        with:
+          colima-network-address: true
+
       - name: Tests
         run: ./gradlew check
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         run: ./gradlew nativeCompile
 
       - name: Codesign binary
-        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
+        if: contains(github.event.head_commit.message, '[release]')
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -114,7 +114,7 @@ jobs:
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime build/native/nativeCompile/migtool -v
 
       - name: Notarize binary
-        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
+        if: contains(github.event.head_commit.message, '[release]')
         env:
           MACOS_AC_API_CERT: ${{ secrets.MACOS_AC_API_CERT }}
           MACOS_AC_API_ISSUER_ID: ${{ secrets.MACOS_AC_API_ISSUER_ID }}
@@ -134,7 +134,7 @@ jobs:
 
   release:
     name: Release
-    if: "contains(github.event.head_commit.message, '[release]') && github.event.ref=='refs/heads/master'"
+    if: "contains(github.event.head_commit.message, '[release]')"
     needs: [ build-linux, build-macos ]
     runs-on: ubuntu-latest
     steps:
@@ -161,6 +161,8 @@ jobs:
 
       - name: Run JReleaser
         uses: jreleaser/release-action@v2
+        with:
+          arguments: --dry-run
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,22 +10,20 @@ on:
       - '**'
 
 jobs:
-  build:
-    name: Migtool build for ${{matrix.os}}
+  build-linux:
+    name: Migtool build for linux-x86
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Environment
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -37,31 +35,28 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
 
-
       - name: Tests
-        if: ${{ !(runner.os == 'macOS' && runner.arch == 'ARM64') }}
         run: ./gradlew check
 
       - name: Tests reports
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ${{matrix.os}}-test-reports
+          name: linux-test-reports
           path: build/reports/tests/test/
           overwrite: true
 
       - name: Build Native Image
         run: ./gradlew nativeCompile
 
-      - name: Upload ${{matrix.os}} native image artifact
+      - name: Upload linux native image artifact
         uses: actions/upload-artifact@v4
         with:
-          name: migtool-${{matrix.os}}
+          name: migtool-linux-x86
           path: build/native/nativeCompile/migtool
           overwrite: true
 
       - name: Tests native
-        if: ${{ !(runner.os == 'macOS' && runner.arch == 'ARM64') }}
         run: ./gradlew cleanTest check
         env:
           NATIVE_BINARY_PATH: build/native/nativeCompile/migtool
@@ -70,14 +65,77 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ${{matrix.os}}-testsNative-reports
+          name: linux-testsNative-reports
           path: build/reports/tests/nativeCliTest/
+          overwrite: true
+
+  build-macos:
+    name: Migtool build for MacOS-arm64
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    runs-on: macos-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Environment
+        run: env | sort
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Graalvm
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+
+      - name: Build Native Image
+        run: ./gradlew nativeCompile
+
+      - name: Codesign binary
+        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_CI_KEYCHAIN_PWD }}
+        run: |
+          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+          /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime build/native/nativeCompile/migtool -v
+
+      - name: Notarize binary
+        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
+        env:
+          MACOS_AC_API_CERT: ${{ secrets.MACOS_AC_API_CERT }}
+          MACOS_AC_API_ISSUER_ID: ${{ secrets.MACOS_AC_API_ISSUER_ID }}
+          MACOS_AC_API_KEY_ID: ${{ secrets.MACOS_AC_API_KEY_ID }}
+        run: |
+          echo $MACOS_AC_API_CERT | base64 --decode > AuthKey.p8
+          xcrun notarytool store-credentials "notarytool-profile" -k AuthKey.p8 -d "$MACOS_AC_API_KEY_ID" -i "$MACOS_AC_API_ISSUER_ID"
+          ditto -c -k --keepParent "build/native/nativeCompile/migtool" "notarization.zip"
+          xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+
+      - name: Upload MacOS native image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: migtool-macos-arm64
+          path: build/native/nativeCompile/migtool
           overwrite: true
 
   release:
     name: Release
     if: "contains(github.event.head_commit.message, '[release]') && github.event.ref=='refs/heads/master'"
-    needs: [ build ]
+    needs: [ build-linux, build-macos ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -99,7 +157,7 @@ jobs:
         run: |
           VERSION=$(cat ./VERSION)
           echo "VERSION = $VERSION"
-          echo "::set-output name=VERSION::$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Run JReleaser
         uses: jreleaser/release-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
           overwrite: true
 
       - name: Tests native
+        if: ${{ !(runner.os == 'macOS' && runner.arch == 'ARM64') }}
         run: ./gradlew cleanTest check
         env:
           NATIVE_BINARY_PATH: build/native/nativeCompile/migtool

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         run: ./gradlew nativeCompile
 
       - name: Codesign binary
-        if: contains(github.event.head_commit.message, '[release]')
+        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -114,7 +114,7 @@ jobs:
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime build/native/nativeCompile/migtool -v
 
       - name: Notarize binary
-        if: contains(github.event.head_commit.message, '[release]')
+        if: contains(github.event.head_commit.message, '[release]') && github.event.ref == 'refs/heads/master'
         env:
           MACOS_AC_API_CERT: ${{ secrets.MACOS_AC_API_CERT }}
           MACOS_AC_API_ISSUER_ID: ${{ secrets.MACOS_AC_API_ISSUER_ID }}
@@ -134,7 +134,7 @@ jobs:
 
   release:
     name: Release
-    if: "contains(github.event.head_commit.message, '[release]')"
+    if: "contains(github.event.head_commit.message, '[release]') && github.event.ref=='refs/heads/master'"
     needs: [ build-linux, build-macos ]
     runs-on: ubuntu-latest
     steps:
@@ -161,8 +161,6 @@ jobs:
 
       - name: Run JReleaser
         uses: jreleaser/release-action@v2
-        with:
-          arguments: --dry-run
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,14 @@ on:
 
 jobs:
   build:
-    name: Migtool build
+    name: Migtool build for ${{matrix.os}}
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     timeout-minutes: 90
     strategy:
       fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Environment
@@ -42,17 +44,17 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: linux-test-reports
+          name: ${{matrix.os}}-test-reports
           path: build/reports/tests/test/
           overwrite: true
 
       - name: Build Native Image
         run: ./gradlew nativeCompile
 
-      - name: Upload linux native image artifact
+      - name: Upload ${{matrix.os}} native image artifact
         uses: actions/upload-artifact@v4
         with:
-          name: migtool-linux
+          name: migtool-${{matrix.os}}
           path: build/native/nativeCompile/migtool
           overwrite: true
 
@@ -65,7 +67,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: linux-testsNative-reports
+          name: ${{matrix.os}}-testsNative-reports
           path: build/reports/tests/nativeCliTest/
           overwrite: true
 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -76,6 +76,9 @@ distributions:
   migtool:
     type: NATIVE_IMAGE
     artifacts:
-      - path: "migtool-linux/migtool"
+      - path: "migtool-ubuntu-latest/migtool"
         transform: "{{distributionName}}-linux-x86_64"
         platform: linux-x86_64
+      - path: "migtool-macos-latest/migtool"
+        transform: "{{distributionName}}-macos-arm64"
+        platform: osx-aarch_64

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -76,9 +76,9 @@ distributions:
   migtool:
     type: NATIVE_IMAGE
     artifacts:
-      - path: "migtool-ubuntu-latest/migtool"
+      - path: "migtool-linux-x86/migtool"
         transform: "{{distributionName}}-linux-x86_64"
         platform: linux-x86_64
-      - path: "migtool-macos-latest/migtool"
+      - path: "migtool-macos-arm64/migtool"
         transform: "{{distributionName}}-macos-arm64"
         platform: osx-aarch_64


### PR DESCRIPTION
# Description

Update the GA runner and JReleaser config to produce and upload Migtool GraalVM executables built for MacOS arm64 (M1, M2, M3, etc) processors.

> [!WARNING]  
> GA MacOS runners don't support running the migtool tests at the moment.

Migtool tests use Docker to spin up a MySQL database in which to run migrations. Currently, Docker does not work in arm64 GA runners because the nested virtualization is not supported for that family of processors :point_right: https://docs.github.com/en/actions/reference/runners/larger-runners#limitations-for-macos-larger-runners

> Nested-virtualization and Metal Performance Shaders (MPS) are not supported due to the limitation of Apple's Virtualization Framework

This may change in the future but, for now, I just skip the tests if running inside the MacOS runner (the tests still run in the Linux runner as usual).

