### PR TITLE
fix Mac build in local machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ finally run it following the example below:
 >
 > Due to current limitations in GraalVM when it comes to running arbitrary Groovy scripts, the binary can only run SQL migration files.
 
-                                                        
+> **Note**
+>
+> When building on macOS, if you encounter the error `com.oracle.svm.core.util.UserError$UserException: DARWIN does not support building static executable images`, you need to remove the `-H:+StaticExecutableWithDynamicLibC` flag from the `buildArgs` in `build.gradle`.
+
+
 #### Options 
 
 * `username`: Target database connection username.

--- a/build.gradle
+++ b/build.gradle
@@ -131,10 +131,7 @@ graalvmNative {
             buildArgs.add('-H:+ReportExceptionStackTraces')
             buildArgs.add('-H:-CheckToolchain')
             buildArgs.add('-H:IncludeResources=.*/TlsSettings.properties$')
-            // Only add static flag on Linux
-            if (org.gradle.internal.os.OperatingSystem.current().isLinux()) {
-                buildArgs.add('-H:+StaticExecutableWithDynamicLibC')
-            }
+            buildArgs.add('-H:+StaticExecutableWithDynamicLibC')
             buildArgs.add('-H:+PrintClassInitialization')
 
             javaLauncher = javaToolchains.launcherFor {

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,10 @@ graalvmNative {
             buildArgs.add('-H:+ReportExceptionStackTraces')
             buildArgs.add('-H:-CheckToolchain')
             buildArgs.add('-H:IncludeResources=.*/TlsSettings.properties$')
-            buildArgs.add('-H:+StaticExecutableWithDynamicLibC')
+            // Only add static flag on Linux
+            if (org.gradle.internal.os.OperatingSystem.current().isLinux()) {
+                buildArgs.add('-H:+StaticExecutableWithDynamicLibC')
+            }
             buildArgs.add('-H:+PrintClassInitialization')
 
             javaLauncher = javaToolchains.launcherFor {


### PR DESCRIPTION
this pr will fix error while building on mac silicon:
```
Error: DARWIN does not support building static executable images.
[8/8] Creating image...       [***]                                                                      (0.0s @ 3.01GB)
com.oracle.svm.core.util.UserError$UserException: DARWIN does not support building static executable images.------------------------------------------------------------------------------------------------------------------------

        at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.UserError.abort(UserError.java:73)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.CCLinkerInvocation$DarwinCCLinkerInvocation.setOutputKind(CCLinkerInvocation.java:431)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.CCLinkerInvocation.getCommand(CCLinkerInvocation.java:206)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.NativeImageViaCC.write(NativeImageViaCC.java:117)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:741)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:550)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:539)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:721)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.start(NativeImageGeneratorRunner.java:143)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:98)
                       7.5s (12.0% of total time) in 205 GCs | Peak RSS: 4.41GB | CPU load: 6.30
========================================================================================================================
Finished generating 'migtool' in 1m 1s.
```