### PR TITLE
fix: do not split SQL statements on semicolons inside comments or string literals DEVOPS-1476

### DIFF
--- a/src/main/java/io/seqera/migtool/MigRecord.java
+++ b/src/main/java/io/seqera/migtool/MigRecord.java
@@ -140,76 +140,63 @@ class MigRecord implements Comparable<MigRecord> {
         }
     }
 
+    /**
+     * Splits the content of a SQL migration file into individual statements.
+     *
+     * Statements are separated by semicolons, but semicolons appearing inside a
+     * line comment ({@code -- ...}), a block comment ({@code /* ... *&#47;}) or a
+     * quoted string literal ({@code '...'} or {@code "..."}) are ignored so they
+     * are not mistaken for statement separators.
+     */
     private static List<String> getSqlStatements(String sql) {
         List<String> result = new ArrayList<>();
-        StringBuilder current = new StringBuilder();
-        int len = sql.length();
-        int i = 0;
+        boolean inLineComment = false;
+        boolean inBlockComment = false;
+        char quote = '\0'; // current open string delimiter, or '\0' when not in a string
+        int start = 0;
 
-        while (i < len) {
+        for (int i = 0; i < sql.length(); i++) {
             char c = sql.charAt(i);
+            char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
 
-            // -- line comment: skip until end of line
-            if (c == '-' && i + 1 < len && sql.charAt(i + 1) == '-') {
-                int end = sql.indexOf('\n', i);
-                if (end == -1) end = len;
-                else end += 1; // include the newline
-                current.append(sql, i, end);
-                i = end;
-                continue;
+            if (inLineComment) {
+                if (c == '\n') inLineComment = false;
             }
-
-            // /* block comment */: skip until */
-            if (c == '/' && i + 1 < len && sql.charAt(i + 1) == '*') {
-                int end = sql.indexOf("*/", i + 2);
-                if (end == -1) end = len;
-                else end += 2; // include the closing */
-                current.append(sql, i, end);
-                i = end;
-                continue;
+            else if (inBlockComment) {
+                if (c == '*' && next == '/') inBlockComment = false;
             }
-
-            // quoted string: skip until matching closing quote (handles '' escapes)
-            if (c == '\'' || c == '"') {
-                char quote = c;
-                current.append(c);
-                i++;
-                while (i < len) {
-                    char qc = sql.charAt(i);
-                    current.append(qc);
-                    i++;
-                    if (qc == quote) {
-                        // handle doubled-quote escape
-                        if (i < len && sql.charAt(i) == quote) {
-                            current.append(sql.charAt(i));
-                            i++;
-                        } else {
-                            break;
-                        }
-                    }
+            else if (quote != '\0') {
+                // inside a string literal: a doubled quote is an escaped quote, not the end
+                if (c == quote) {
+                    if (next == quote) i++;
+                    else quote = '\0';
                 }
-                continue;
             }
-
-            if (c == ';') {
-                String clean = current.toString().trim();
-                if (!clean.isEmpty())
-                    result.add(clean + ';');
-                current.setLength(0);
-                i++;
-                continue;
+            else if (c == '-' && next == '-') {
+                inLineComment = true;
             }
-
-            current.append(c);
-            i++;
+            else if (c == '/' && next == '*') {
+                inBlockComment = true;
+            }
+            else if (c == '\'' || c == '"') {
+                quote = c;
+            }
+            else if (c == ';') {
+                addStatement(result, sql.substring(start, i));
+                start = i + 1;
+            }
         }
 
         // trailing content with no closing semicolon
-        String clean = current.toString().trim();
-        if (!clean.isEmpty())
-            result.add(clean + ';');
+        addStatement(result, sql.substring(start));
 
         return result;
+    }
+
+    private static void addStatement(List<String> statements, String statement) {
+        String clean = statement.trim();
+        if (!clean.isEmpty())
+            statements.add(clean + ';');
     }
 
     private static String join(List<String> items) {

--- a/src/main/java/io/seqera/migtool/MigRecord.java
+++ b/src/main/java/io/seqera/migtool/MigRecord.java
@@ -141,14 +141,73 @@ class MigRecord implements Comparable<MigRecord> {
     }
 
     private static List<String> getSqlStatements(String sql) {
-        String[] tokens = sql.split(";");
-        List<String> result = new ArrayList<>(tokens.length);
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        int len = sql.length();
+        int i = 0;
 
-        for( int i=0; i<tokens.length; i++) {
-            String clean = tokens[i].trim();
-            if( clean.length()>0 )
-                result.add( clean + ';' ) ;
+        while (i < len) {
+            char c = sql.charAt(i);
+
+            // -- line comment: skip until end of line
+            if (c == '-' && i + 1 < len && sql.charAt(i + 1) == '-') {
+                int end = sql.indexOf('\n', i);
+                if (end == -1) end = len;
+                else end += 1; // include the newline
+                current.append(sql, i, end);
+                i = end;
+                continue;
+            }
+
+            // /* block comment */: skip until */
+            if (c == '/' && i + 1 < len && sql.charAt(i + 1) == '*') {
+                int end = sql.indexOf("*/", i + 2);
+                if (end == -1) end = len;
+                else end += 2; // include the closing */
+                current.append(sql, i, end);
+                i = end;
+                continue;
+            }
+
+            // quoted string: skip until matching closing quote (handles '' escapes)
+            if (c == '\'' || c == '"') {
+                char quote = c;
+                current.append(c);
+                i++;
+                while (i < len) {
+                    char qc = sql.charAt(i);
+                    current.append(qc);
+                    i++;
+                    if (qc == quote) {
+                        // handle doubled-quote escape
+                        if (i < len && sql.charAt(i) == quote) {
+                            current.append(sql.charAt(i));
+                            i++;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                continue;
+            }
+
+            if (c == ';') {
+                String clean = current.toString().trim();
+                if (!clean.isEmpty())
+                    result.add(clean + ';');
+                current.setLength(0);
+                i++;
+                continue;
+            }
+
+            current.append(c);
+            i++;
         }
+
+        // trailing content with no closing semicolon
+        String clean = current.toString().trim();
+        if (!clean.isEmpty())
+            result.add(clean + ';');
 
         return result;
     }

--- a/src/test/groovy/io/seqera/migtool/MigRecordTest.groovy
+++ b/src/test/groovy/io/seqera/migtool/MigRecordTest.groovy
@@ -220,6 +220,34 @@ class MigRecordTest extends Specification {
         folder?.deleteDir()
     }
 
+    def 'should not split on semicolons inside string literals'() {
+        given:
+        def folder = Files.createTempDirectory('test')
+
+        // semicolon inside a single-quoted string must NOT be treated as a statement separator
+        final file1 = folder.resolve('V01__file1.sql')
+        file1.text = "insert into XXX ( col1 ) values ( 'a; b' );"
+
+        // a doubled-quote escape inside a string must not close the string prematurely
+        final file2 = folder.resolve('V02__file2.sql')
+        file2.text = "insert into YYY ( col1 ) values ( 'it''s; ok' );"
+
+        when:
+        def entry1 = MigRecord.parseFilePath(file1, null)
+        def entry2 = MigRecord.parseFilePath(file2, null)
+
+        then: 'the single-quoted string should not produce an extra statement'
+        entry1.statements.size() == 1
+        entry1.statements == ["insert into XXX ( col1 ) values ( 'a; b' );"]
+
+        and: 'the escaped-quote string should not produce an extra statement'
+        entry2.statements.size() == 1
+        entry2.statements == ["insert into YYY ( col1 ) values ( 'it''s; ok' );"]
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
     def 'compare records for SQL files with same statements'() {
         given: 'some files with the same statements'
         def folder = Files.createTempDirectory('test')

--- a/src/test/groovy/io/seqera/migtool/MigRecordTest.groovy
+++ b/src/test/groovy/io/seqera/migtool/MigRecordTest.groovy
@@ -192,6 +192,34 @@ class MigRecordTest extends Specification {
         entry1.checksum == '71a8b87777c309059c43f8157d20ffcf25edd1669c4163f8eb2b48ddb663616e'
     }
 
+    def 'should not split on semicolons inside SQL comments'() {
+        given:
+        def folder = Files.createTempDirectory('test')
+
+        // semicolon inside a -- line comment must NOT be treated as a statement separator
+        final file1 = folder.resolve('V01__file1.sql')
+        file1.text = '-- this is a comment; not a separator\ncreate table XXX ( col1 varchar(1) );'
+
+        // semicolon inside a /* block comment */ must NOT be treated as a statement separator
+        final file2 = folder.resolve('V02__file2.sql')
+        file2.text = '/* block comment; still a comment */\ncreate table YYY ( col1 varchar(1) );'
+
+        when:
+        def entry1 = MigRecord.parseFilePath(file1, null)
+        def entry2 = MigRecord.parseFilePath(file2, null)
+
+        then: 'the comment line should not produce an extra statement'
+        entry1.statements.size() == 1
+        entry1.statements == ['-- this is a comment; not a separator\ncreate table XXX ( col1 varchar(1) );']
+
+        and: 'the block comment should not produce an extra statement'
+        entry2.statements.size() == 1
+        entry2.statements == ['/* block comment; still a comment */\ncreate table YYY ( col1 varchar(1) );']
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
     def 'compare records for SQL files with same statements'() {
         given: 'some files with the same statements'
         def folder = Files.createTempDirectory('test')


### PR DESCRIPTION
## Summary

- `getSqlStatements` was using a naive `sql.split(";")` which caused semicolons inside `--` line comments, `/* */` block comments, and quoted string literals to be treated as statement separators
- Replaced the split-based approach with a character-by-character parser that skips over comments and quoted strings when looking for statement-terminating semicolons

## Test plan

- [ ] New test `'should not split on semicolons inside SQL comments'` in `MigRecordTest` covers `--` line comments and `/* */` block comments — was failing before the fix, passes after
- [ ] All existing unit tests (`MigRecordTest`, `MigToolTest`, `HelperTest`, `SqliteTest`, `SqlTemplateTest`) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)