### PR TITLE
fix: [release] add back contents:write for jreleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,7 @@ jobs:
     needs: [ build-linux, build-macos ]
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
I just discovered that `contents:write` is set by default on all GHAs and once a new set of permissions are set (like I did in #72 by setting `id-token:write`) the default ones are dropped.